### PR TITLE
Kickoff marinade TS lib transformation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
         "muln"
-    ]
+    ],
+    "editor.formatOnSave": false
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/marinade-finance/marinade-ts-cli.git
 cd marinade-ts-cli
 npm install
 npm run build
-node dist/marinade show
+node dist/marinade-cli show
 ```
 
 ## Changelog

--- a/src/commands/add-liquidity.ts
+++ b/src/commands/add-liquidity.ts
@@ -1,11 +1,11 @@
-import { BN, Wallet } from '@project-serum/anchor'
+import { Wallet } from '@project-serum/anchor'
 import { Marinade } from '../marinade'
 import { MarinadeConfig } from '../modules/marinade-config'
 import { solToLamportsBN } from '../util/conversion'
 
-export const addLiquidity = async (amount: number, { sol }: { sol: boolean }): Promise<void> => {
-  const amountLamports = sol ? solToLamportsBN(amount) : new BN(amount)
-  console.log('Adding liquidity:', amountLamports, 'lamports')
+export async function addLiquidityAction (amountSol: string | number): Promise<void> {
+  const amountLamports = solToLamportsBN(Number(amountSol))
+  console.log('Adding liquidity:', amountSol, 'SOL', amountLamports.toString(), 'lamports')
 
   const marinadeConfig = new MarinadeConfig({ wallet: Wallet.local().payer })
   const marinade = new Marinade(marinadeConfig)

--- a/src/commands/add-liquidity.ts
+++ b/src/commands/add-liquidity.ts
@@ -1,0 +1,21 @@
+import { BN, Wallet } from '@project-serum/anchor'
+import { Marinade } from '../marinade'
+import { MarinadeConfig } from '../modules/marinade-config'
+import { solToLamportsBN } from '../util/conversion'
+
+export const addLiquidity = async (amount: number, { sol }: { sol: boolean }): Promise<void> => {
+  const amountLamports = sol ? solToLamportsBN(amount) : new BN(amount)
+  console.log('Adding liquidity:', amountLamports, 'lamports')
+
+  const marinadeConfig = new MarinadeConfig({ wallet: Wallet.local().payer })
+  const marinade = new Marinade(marinadeConfig)
+  const {
+    associatedTokenAccountAddress,
+    transactionSignature,
+  } = await marinade.addLiquidity(amountLamports)
+
+  console.log('Solana net:', marinade.config.anchorProviderUrl)
+  console.log('Using fee payer', marinade.config.wallet.publicKey.toBase58())
+  console.log('Using associated smart-lp account', associatedTokenAccountAddress.toBase58())
+  console.log('Transaction', transactionSignature)
+}

--- a/src/commands/remove-liquidity.ts
+++ b/src/commands/remove-liquidity.ts
@@ -1,21 +1,21 @@
 import { BN, Wallet } from '@project-serum/anchor'
 import { Marinade } from '../marinade'
 import { MarinadeConfig } from '../modules/marinade-config'
-import { solToLamportsBN } from '../util/conversion'
 
-export const addLiquidity = async (amount: number, { sol }: { sol: boolean }): Promise<void> => {
-  const amountLamports = sol ? solToLamportsBN(amount) : new BN(amount)
-  console.log('Adding liquidity:', amountLamports, 'lamports')
+export const removeLiquidity = async (amount: number): Promise<void> => {
+  console.log('Removing liquidity:', amount, 'LP tokens')
 
   const marinadeConfig = new MarinadeConfig({ wallet: Wallet.local().payer })
   const marinade = new Marinade(marinadeConfig)
   const {
     associatedLPTokenAccountAddress,
+    associatedMSolTokenAccountAddress,
     transactionSignature,
-  } = await marinade.addLiquidity(amountLamports)
+  } = await marinade.removeLiquidity(amount)
 
   console.log('Solana net:', marinade.config.anchorProviderUrl)
   console.log('Using fee payer', marinade.config.wallet.publicKey.toBase58())
   console.log('Using associated smart-lp account', associatedLPTokenAccountAddress.toBase58())
+  console.log('Using associated msol account', associatedMSolTokenAccountAddress.toBase58())
   console.log('Transaction', transactionSignature)
 }

--- a/src/commands/remove-liquidity.ts
+++ b/src/commands/remove-liquidity.ts
@@ -1,9 +1,11 @@
-import { BN, Wallet } from '@project-serum/anchor'
+import { Wallet } from '@project-serum/anchor'
 import { Marinade } from '../marinade'
 import { MarinadeConfig } from '../modules/marinade-config'
+import { solToLamportsBN } from '../util/conversion'
 
-export const removeLiquidity = async (amount: number): Promise<void> => {
-  console.log('Removing liquidity:', amount, 'LP tokens')
+export async function removeLiquidityAction (amountSol: string | number): Promise<void> {
+  const amountLamports = solToLamportsBN(Number(amountSol))
+  console.log('Removing liquidity:', amountSol, 'SOL', amountLamports.toString(), 'lamports')
 
   const marinadeConfig = new MarinadeConfig({ wallet: Wallet.local().payer })
   const marinade = new Marinade(marinadeConfig)
@@ -11,7 +13,7 @@ export const removeLiquidity = async (amount: number): Promise<void> => {
     associatedLPTokenAccountAddress,
     associatedMSolTokenAccountAddress,
     transactionSignature,
-  } = await marinade.removeLiquidity(amount)
+  } = await marinade.removeLiquidity(amountLamports)
 
   console.log('Solana net:', marinade.config.anchorProviderUrl)
   console.log('Using fee payer', marinade.config.wallet.publicKey.toBase58())

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -73,5 +73,4 @@ export const show = async (): Promise<void> => {
   console.log("  Total Staked Value (SOL) ", tvlStaked.toLocaleString())
   console.log("  Total Liquidity-Pool (SOL) ", tvlLiquidity.toLocaleString())
   console.log("  TVL (SOL) ", (tvlStaked + tvlLiquidity).toLocaleString())
-
 }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -2,8 +2,8 @@ import BN from 'bn.js'
 import { Marinade } from '../marinade'
 import { lamportsToSolNumber } from '../util/conversion'
 
-export async function show(): Promise<void> {
-  // const marinade = new Marinade(new Config({ anchorProviderUrl: '...://...' }))
+export const show = async (): Promise<void> => {
+  // const marinade = new Marinade(new MarinadeConfig({ anchorProviderUrl: '...://...' }))
   const marinade = new Marinade()
   const marinadeState = await marinade.getMarinadeState()
 

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,73 +1,77 @@
-import { web3, Provider, Program, Idl, BN } from "@project-serum/anchor";
-import { Token, TOKEN_PROGRAM_ID, MintInfo, AccountInfo as TokenAccountInfo } from "@solana/spl-token";
-import * as marinadeIdl from "../marinade-idl.json";
-import { lamportsToSolBN, tokenBalanceToNumber } from "../util/conversion";
+import BN from 'bn.js'
+import { Marinade } from '../marinade'
+import { lamportsToSolNumber } from '../util/conversion'
 
 export async function show(): Promise<void> {
+  // const marinade = new Marinade(new Config({ anchorProviderUrl: '...://...' }))
+  const marinade = new Marinade()
+  const marinadeState = await marinade.getMarinadeState()
 
-  const marinadeProgramId = new web3.PublicKey("MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD")
+  const {
+    state,
+    lpMint,
+    mSolMint,
+    mSolMintAddress,
+    mSolPrice,
+    mSolLeg, // @todo fetch from Marinade instead for MarinadeState? This should be configurable https://docs.marinade.finance/developers/contract-addresses
+    treasuryMsolAccount,
+    rewardsCommissionPercent,
+  } = marinadeState
 
-  process.env.ANCHOR_PROVIDER_URL = "http://api.mainnet-beta.solana.com"
-  const anchorProvider = Provider.env()
-  //new Provider(connection, wallet, Provider.defaultOptions());
+  const mSolMintClient = mSolMint.mintClient()
+  const mSolMintBalance = await mSolMint.tokenBalance()
 
-  const program = new Program(
-    marinadeIdl as Idl,
-    marinadeProgramId,
-    anchorProvider,
-  );
+  const lpMintClient = lpMint.mintClient()
+  const lpMintInfo = await lpMintClient.getMintInfo()
+  const lpMintBalance = await lpMint.tokenBalance()
 
-  const marinadeStateAddress = new web3.PublicKey("8szGkuLTAux9XMgZ2vtY39jVSowEcpBfFfD8hXSEqdGC")
+  const mSolLegInfo = await mSolMintClient.getAccountInfo(state.liqPool.msolLeg)
+  const mSolLegBalance = mSolLegInfo.amount
 
-  let state: any = await program.account.state.fetch(marinadeStateAddress)
-  console.log(state)
+  const solLeg = await marinadeState.solLeg() // @todo fetch from Marinade instead?, rm await
+  const solLegBalance = new BN(await marinade.anchorProvider.connection.getBalance(solLeg)).sub(state.rentExemptForTokenAcc)
 
-  console.log("Marinade.Finance ProgramId", marinadeProgramId.toBase58())
-  console.log("Marinade.Finance state", marinadeStateAddress.toBase58())
+  const tvlStaked = Math.round(mSolMintBalance * mSolPrice) // @todo move as getter to MarinadeState
+  const totalLiqPoolValue = solLegBalance.add(mSolLegBalance.muln(mSolPrice))
+  const tvlLiquidity = Math.round(lamportsToSolNumber(totalLiqPoolValue))
+
+  const LPPrice = totalLiqPoolValue.mul(new BN(10 ** lpMintInfo.decimals)).div(lpMintInfo.supply)
+
+  console.log(state) // Access to raw internal structure is allowed
+
+  console.log("Marinade.Finance ProgramId", marinade.config.marinadeProgramId.toBase58())
+  console.log("Marinade.Finance State", marinade.config.marinadeStateAddress.toBase58())
   console.log()
 
-  console.log("mSOL mint", state.msolMint.toBase58())
-  const mSolMintClient = new Token(anchorProvider.connection, state.msolMint, TOKEN_PROGRAM_ID, web3.Keypair.generate());
-  const mSolMintInfo = await mSolMintClient.getMintInfo();
-  console.log("mSOL supply", tokenBalanceToNumber(mSolMintInfo.supply, mSolMintInfo.decimals))
+  console.log("mSOL mint", mSolMintAddress.toBase58())
+  console.log("mSOL supply", mSolMintBalance)
   console.log()
 
-  console.log("Treasury mSOL account", state.treasuryMsolAccount.toBase58())
-  console.log("Rewards commission", state.rewardFee.basisPoints / 100, "%")
+  console.log("Treasury mSOL account", treasuryMsolAccount.toBase58())
+  console.log("Rewards commission", rewardsCommissionPercent, "%")
   console.log("Stake Account Count", state.stakeSystem.stakeList.count)
-  console.log("Min Stake Amounts", lamportsToSolBN(state.stakeSystem.minStake))
+  console.log("Min Stake Amounts", lamportsToSolNumber(state.stakeSystem.minStake))
   console.log()
 
-  const msolPrice = state.msolPrice.toNumber() / 0x1_0000_0000;
-  console.log("mSol Price", msolPrice)
+  console.log("mSol Price", mSolPrice)
   console.log()
 
   console.log("--- mSOL-SOL swap pool")
-  console.log("LP Mint", state.liqPool.lpMint.toBase58())
-  const lpMintClient = new Token(anchorProvider.connection, state.liqPool.lpMint, TOKEN_PROGRAM_ID, web3.Keypair.generate());
-  const lpMintInfo = await lpMintClient.getMintInfo();
-  console.log("  LP supply: ", tokenBalanceToNumber(lpMintInfo.supply, lpMintInfo.decimals))
+  console.log("LP Mint", marinadeState.lpMintAddress.toBase58())
+  console.log("  LP supply: ", lpMintBalance)
 
-  const [solLeg, solLegBump] = await web3.PublicKey.findProgramAddress([marinadeStateAddress.toBuffer(), Buffer.from("liq_sol")], marinadeProgramId)
   console.log("  SOL leg", solLeg.toBase58())
-  const solLegBalance = new BN(await anchorProvider.connection.getBalance(solLeg)).sub(state.rentExemptForTokenAcc)
-  console.log("  SOL leg Balance", lamportsToSolBN(solLegBalance))
+  console.log("  SOL leg Balance", lamportsToSolNumber(solLegBalance))
 
-  console.log("  mSOL leg", state.liqPool.msolLeg.toBase58())
-  const mSolLegInfo = await mSolMintClient.getAccountInfo(state.liqPool.msolLeg);
-  const mSolLegBalance = mSolLegInfo.amount
-  console.log("  mSOL leg Balance", lamportsToSolBN(mSolLegBalance))
-  const totalLiqPoolValue = solLegBalance.add(mSolLegBalance.muln(msolPrice))
+  console.log("  mSOL leg", mSolLeg.toBase58())
+  console.log("  mSOL leg Balance", lamportsToSolNumber(mSolLegBalance))
 
-  console.log("  Total Liq pool value (SOL) ", lamportsToSolBN(totalLiqPoolValue))
-  const LPPrice = totalLiqPoolValue.mul(new BN(10 ** lpMintInfo.decimals)).div(lpMintInfo.supply)
-  console.log("  mSOL-SOL-LP price (SOL)", lamportsToSolBN(LPPrice))
+  console.log("  Total Liq pool value (SOL) ", lamportsToSolNumber(totalLiqPoolValue))
+  console.log("  mSOL-SOL-LP price (SOL)", lamportsToSolNumber(LPPrice))
 
   console.log("--- TVL")
-  const tvlStaked = Math.round(tokenBalanceToNumber(mSolMintInfo.supply, mSolMintInfo.decimals) * msolPrice)
   console.log("  Total Staked Value (SOL) ", tvlStaked.toLocaleString())
-  const tvlLiquidity = Math.round(lamportsToSolBN(totalLiqPoolValue))
   console.log("  Total Liquidity-Pool (SOL) ", tvlLiquidity.toLocaleString())
-  console.log("  TVL (SOL) ", (tvlStaked+tvlLiquidity).toLocaleString())
+  console.log("  TVL (SOL) ", (tvlStaked + tvlLiquidity).toLocaleString())
 
 }

--- a/src/marinade-cli.ts
+++ b/src/marinade-cli.ts
@@ -1,8 +1,8 @@
 #!/bin/node
-import { program } from "commander";
-import { show } from "./commands/show";
-import { addLiquidity } from "./commands/add-liquidity";
-import { removeLiquidity } from './commands/remove-liquidity'
+import { program } from "commander"
+import { show } from "./commands/show"
+import { addLiquidityAction } from "./commands/add-liquidity"
+import { removeLiquidityAction } from './commands/remove-liquidity'
 
 async function main(argv: string[], _env: Record<string, unknown>) {
 
@@ -16,15 +16,14 @@ async function main(argv: string[], _env: Record<string, unknown>) {
     .action(show)
 
   program
-    .command("add-liquidity <amount>")
+    .command("add-liquidity <amount-sol>")
     .description("provide liquidity to the liquidity pool")
-    .option("--sol", "amount measured in SOL", false)
-    .action(addLiquidity)
+    .action(addLiquidityAction)
 
   program
-    .command("remove-liquidity <lp-token-amount>")
+    .command("remove-liquidity <amount-sol>")
     .description("remove liquidity from the liquidity pool")
-    .action(removeLiquidity)
+    .action(removeLiquidityAction)
 
   // program
   //   .command("stake <amount>")

--- a/src/marinade-cli.ts
+++ b/src/marinade-cli.ts
@@ -1,17 +1,24 @@
 #!/bin/node
 import { program } from "commander";
-import { show } from "./commands/show.js";
+import { show } from "./commands/show";
+import { addLiquidity } from "./commands/add-liquidity";
 
 async function main(argv: string[], _env: Record<string, unknown>) {
 
   program
     .version("0.0.1")
-    .allowExcessArguments(false);
+    .allowExcessArguments(false)
 
   program
     .command("show")
     .description("show marinade state")
-    .action(show);
+    .action(show)
+
+  program
+    .command("add-liquidity <amount>")
+    .description("provide liquidity to the liquidity pool")
+    .option("--sol", "amount measured in SOL", false)
+    .action(addLiquidity)
 
   // program
   //   .command("stake <amount>")
@@ -26,9 +33,9 @@ async function main(argv: string[], _env: Record<string, unknown>) {
   //   .description("unstake mSOL, get SOL")
   //   .action(unstakeNow);
 
-  program.parse(argv);
+  program.parse(argv)
 
 }
 
-main(process.argv, process.env);
+main(process.argv, process.env)
 

--- a/src/marinade-cli.ts
+++ b/src/marinade-cli.ts
@@ -2,6 +2,7 @@
 import { program } from "commander";
 import { show } from "./commands/show";
 import { addLiquidity } from "./commands/add-liquidity";
+import { removeLiquidity } from './commands/remove-liquidity'
 
 async function main(argv: string[], _env: Record<string, unknown>) {
 
@@ -14,11 +15,16 @@ async function main(argv: string[], _env: Record<string, unknown>) {
     .description("show marinade state")
     .action(show)
 
-  program
-    .command("add-liquidity <amount>")
-    .description("provide liquidity to the liquidity pool")
-    .option("--sol", "amount measured in SOL", false)
-    .action(addLiquidity)
+    program
+      .command("add-liquidity <amount>")
+      .description("provide liquidity to the liquidity pool")
+      .option("--sol", "amount measured in SOL", false)
+      .action(addLiquidity)
+
+    program
+      .command("remove-liquidity <lp-token-amount>")
+      .description("remove liquidity from the liquidity pool")
+      .action(removeLiquidity)
 
   // program
   //   .command("stake <amount>")

--- a/src/marinade-cli.ts
+++ b/src/marinade-cli.ts
@@ -1,0 +1,34 @@
+#!/bin/node
+import { program } from "commander";
+import { show } from "./commands/show.js";
+
+async function main(argv: string[], _env: Record<string, unknown>) {
+
+  program
+    .version("0.0.1")
+    .allowExcessArguments(false);
+
+  program
+    .command("show")
+    .description("show marinade state")
+    .action(show);
+
+  // program
+  //   .command("stake <amount>")
+  //   .description("stake SOL get mSOL")
+  //   .action(stake);
+
+  // program
+  //   .command("unstake <amount>")
+  //   .option("-f, --max-fee","max fee accepted")
+  //   .option("-m, --min-sol","min SOL accepted")
+  //   .option("--sol","amount measured in sol")
+  //   .description("unstake mSOL, get SOL")
+  //   .action(unstakeNow);
+
+  program.parse(argv);
+
+}
+
+main(process.argv, process.env);
+

--- a/src/marinade-cli.ts
+++ b/src/marinade-cli.ts
@@ -15,16 +15,16 @@ async function main(argv: string[], _env: Record<string, unknown>) {
     .description("show marinade state")
     .action(show)
 
-    program
-      .command("add-liquidity <amount>")
-      .description("provide liquidity to the liquidity pool")
-      .option("--sol", "amount measured in SOL", false)
-      .action(addLiquidity)
+  program
+    .command("add-liquidity <amount>")
+    .description("provide liquidity to the liquidity pool")
+    .option("--sol", "amount measured in SOL", false)
+    .action(addLiquidity)
 
-    program
-      .command("remove-liquidity <lp-token-amount>")
-      .description("remove liquidity from the liquidity pool")
-      .action(removeLiquidity)
+  program
+    .command("remove-liquidity <lp-token-amount>")
+    .description("remove liquidity from the liquidity pool")
+    .action(removeLiquidity)
 
   // program
   //   .command("stake <amount>")

--- a/src/marinade-mint/marinade-mint.ts
+++ b/src/marinade-mint/marinade-mint.ts
@@ -1,0 +1,23 @@
+import { Provider, web3 } from '@project-serum/anchor'
+import { MintInfo, Token } from '@solana/spl-token'
+import { mintClient } from '../util/anchor'
+import { tokenBalanceToNumber } from '../util/conversion'
+
+export class MarinadeMint {
+  private constructor (
+    private readonly anchorProvider: Provider,
+    public readonly address: web3.PublicKey
+  ) { }
+
+  static build (anchorProvider: Provider, mintAddress: web3.PublicKey): MarinadeMint {
+    return new MarinadeMint(anchorProvider, mintAddress)
+  }
+
+  mintClient = (): Token => mintClient(this.anchorProvider, this.address)
+  mintInfo = (): Promise<MintInfo> => this.mintClient().getMintInfo()
+
+  async tokenBalance (mintInfoCached?: MintInfo): Promise<number> {
+    const mintInfo = mintInfoCached ?? await this.mintInfo()
+    return tokenBalanceToNumber(mintInfo.supply, mintInfo.decimals)
+  }
+}

--- a/src/marinade-mint/marinade-mint.ts
+++ b/src/marinade-mint/marinade-mint.ts
@@ -1,6 +1,6 @@
 import { Provider, web3 } from '@project-serum/anchor'
 import { MintInfo, Token } from '@solana/spl-token'
-import { mintClient } from '../util/anchor'
+import { getMintClient } from '../util/anchor'
 import { tokenBalanceToNumber } from '../util/conversion'
 
 export class MarinadeMint {
@@ -13,7 +13,7 @@ export class MarinadeMint {
     return new MarinadeMint(anchorProvider, mintAddress)
   }
 
-  mintClient = (): Token => mintClient(this.anchorProvider, this.address)
+  mintClient = (): Token => getMintClient(this.anchorProvider, this.address)
   mintInfo = (): Promise<MintInfo> => this.mintClient().getMintInfo()
 
   async tokenBalance (mintInfoCached?: MintInfo): Promise<number> {

--- a/src/marinade-state/marinade-state.ts
+++ b/src/marinade-state/marinade-state.ts
@@ -23,6 +23,7 @@ export class MarinadeState {
   mSolMint = MarinadeMint.build(this.anchorProvider, this.mSolMintAddress)
 
   lpMintAddress: web3.PublicKey = this.state.liqPool.lpMint
+  lpMintAuthority: web3.PublicKey = new web3.PublicKey('HZsepB79dnpvH6qfVgvMpS738EndHw3qSHo4Gv5WX1KA') // @todo get from config/some other place?
   lpMint = MarinadeMint.build(this.anchorProvider, this.lpMintAddress)
 
   mSolLeg = this.state.liqPool.msolLeg

--- a/src/marinade-state/marinade-state.ts
+++ b/src/marinade-state/marinade-state.ts
@@ -1,7 +1,7 @@
 import { Provider, web3 } from '@project-serum/anchor'
 import { Marinade } from '../marinade'
 import { MarinadeMint } from '../marinade-mint/marinade-mint'
-import { MarinadeStateResponse } from './marinade-state.types'
+import { LiquidityPoolSeed, MarinadeStateResponse } from './marinade-state.types'
 
 export class MarinadeState {
   // @todo rework args
@@ -21,18 +21,19 @@ export class MarinadeState {
 
   mSolMintAddress: web3.PublicKey = this.state.msolMint
   mSolMint = MarinadeMint.build(this.anchorProvider, this.mSolMintAddress)
-
-  lpMintAddress: web3.PublicKey = this.state.liqPool.lpMint
-  lpMintAuthority: web3.PublicKey = new web3.PublicKey('HZsepB79dnpvH6qfVgvMpS738EndHw3qSHo4Gv5WX1KA') // @todo get from config/some other place?
-  lpMint = MarinadeMint.build(this.anchorProvider, this.lpMintAddress)
-
+  mSolLegAuthority = async () => this.findLiquidityPoolProgramAddress(LiquidityPoolSeed.MSOL_LEG_AUTHORITY_SEED)
   mSolLeg = this.state.liqPool.msolLeg
 
-  // @todo solLeg = this.state.liqPool.???
-  async solLeg () {
-    const seeds = [this.marinade.config.marinadeStateAddress.toBuffer(), Buffer.from("liq_sol")]
-    const [solLeg] = await web3.PublicKey.findProgramAddress(seeds, this.marinade.config.marinadeProgramId)
-    return solLeg
+  lpMintAddress: web3.PublicKey = this.state.liqPool.lpMint
+  lpMint = MarinadeMint.build(this.anchorProvider, this.lpMintAddress)
+  lpMintAuthority = async () => this.findLiquidityPoolProgramAddress(LiquidityPoolSeed.LP_MINT_AUTHORITY_SEED)
+
+  solLeg = async () => this.findLiquidityPoolProgramAddress(LiquidityPoolSeed.SOL_LEG_SEED)
+
+  private async findLiquidityPoolProgramAddress (seed: LiquidityPoolSeed): Promise<web3.PublicKey> {
+    const seeds = [this.marinade.config.marinadeStateAddress.toBuffer(), Buffer.from(seed)]
+    const [result] = await web3.PublicKey.findProgramAddress(seeds, this.marinade.config.marinadeProgramId)
+    return result
   }
 
   treasuryMsolAccount: web3.PublicKey = this.state.treasuryMsolAccount

--- a/src/marinade-state/marinade-state.ts
+++ b/src/marinade-state/marinade-state.ts
@@ -1,0 +1,43 @@
+import { Provider, web3 } from '@project-serum/anchor'
+import { Marinade } from '../marinade'
+import { MarinadeMint } from '../marinade-mint/marinade-mint'
+import { MarinadeStateResponse } from './marinade-state.types'
+
+export class MarinadeState {
+  // @todo rework args
+  private constructor (
+    private readonly marinade: Marinade,
+    private readonly anchorProvider: Provider,
+    public readonly state: MarinadeStateResponse,
+  ) { }
+
+  static async fetch (marinade: Marinade) { // @todo rework args
+    const { marinadeProgram, config } = marinade
+    const state = await marinadeProgram.account.state.fetch(config.marinadeStateAddress) as MarinadeStateResponse
+    return new MarinadeState(marinade, marinade.anchorProvider, state)
+  }
+
+  mSolPrice: number = this.state.msolPrice.toNumber() / 0x1_0000_0000
+
+  mSolMintAddress: web3.PublicKey = this.state.msolMint
+  mSolMint = MarinadeMint.build(this.anchorProvider, this.mSolMintAddress)
+
+  lpMintAddress: web3.PublicKey = this.state.liqPool.lpMint
+  lpMint = MarinadeMint.build(this.anchorProvider, this.lpMintAddress)
+
+  mSolLeg = this.state.liqPool.msolLeg
+
+  // @todo solLeg = this.state.liqPool.???
+  async solLeg () {
+    const seeds = [this.marinade.config.marinadeStateAddress.toBuffer(), Buffer.from("liq_sol")]
+    const [solLeg] = await web3.PublicKey.findProgramAddress(seeds, this.marinade.config.marinadeProgramId)
+    return solLeg
+  }
+
+  treasuryMsolAccount: web3.PublicKey = this.state.treasuryMsolAccount
+
+  /**
+   * Commission in %
+   */
+  rewardsCommissionPercent: number = this.state.rewardFee.basisPoints / 100
+}

--- a/src/marinade-state/marinade-state.types.ts
+++ b/src/marinade-state/marinade-state.types.ts
@@ -1,0 +1,73 @@
+import type { web3, BN } from '@project-serum/anchor'
+
+export namespace MarinadeStateResponse {
+  export interface Fee {
+    basisPoints: number
+  }
+
+  export interface AccountList {
+    account: web3.PublicKey[]
+    itemSize: number
+    count: number
+    newAccount: web3.PublicKey[]
+    copiedCount: number
+  }
+
+  export interface StakeSystem {
+    stakeList: AccountList
+    delayedUnstakeCoolingDown: BN
+    stakeDepositBumpSeed: number
+    stakeWithdrawBumpSeed: number
+    slotsForStakeDelta: BN
+    lastStakeDeltaEpoch: BN
+    minStake: BN
+    extraStakeDeltaRuns: number
+  }
+
+  export interface ValidatorSystem {
+    validatorList: AccountList
+    managerAuthority: web3.PublicKey
+    totalValidatorScore: number
+    totalActiveBalance: BN
+    autoAddValidatorEnabled: number
+  }
+
+  export interface LiqPool {
+    lpMint: web3.PublicKey
+    lpMintAuthorityBumpSeed: number
+    solLegBumpSeed: number
+    msolLegAuthorityBumpSeed: number
+    msolLeg: web3.PublicKey
+    lpLiquidityTarget: BN
+    lpMaxFee: Fee
+    lpMinFee: Fee
+    treasuryCut: Fee
+    lpSupply: BN
+    lentFromSolLeg: BN
+    liquiditySolCap: BN
+  }
+}
+
+export interface MarinadeStateResponse {
+  msolMint: web3.PublicKey
+  adminAuthority: web3.PublicKey
+  operationalSolAccount: web3.PublicKey
+  treasuryMsolAccount: web3.PublicKey
+  reserveBumpSeed: number
+  msolMintAuthorityBumpSeed: number
+  rentExemptForTokenAcc: BN
+  rewardFee: MarinadeStateResponse.Fee
+  stakeSystem: MarinadeStateResponse.StakeSystem
+  validatorSystem: MarinadeStateResponse.ValidatorSystem
+  liqPool: MarinadeStateResponse.LiqPool
+  availableReserveBalance: BN
+  msolSupply: BN
+  msolPrice: BN
+  circulatingTicketCount: BN
+  circulatingTicketBalance: BN
+  lentFromReserve: BN
+  minDeposit: BN
+  minWithdraw: BN
+  stakingSolCap: BN
+  emergencyCoolingDown: BN
+}

--- a/src/marinade-state/marinade-state.types.ts
+++ b/src/marinade-state/marinade-state.types.ts
@@ -1,5 +1,12 @@
 import type { web3, BN } from '@project-serum/anchor'
 
+export const enum LiquidityPoolSeed {
+  LP_MINT_AUTHORITY_SEED = 'liq_mint',
+  SOL_LEG_SEED = 'liq_sol',
+  MSOL_LEG_AUTHORITY_SEED = 'liq_st_sol_authority',
+  MSOL_LEG_SEED = 'liq_st_sol',
+}
+
 export namespace MarinadeStateResponse {
   export interface Fee {
     basisPoints: number

--- a/src/marinade.ts
+++ b/src/marinade.ts
@@ -3,7 +3,7 @@ import { BN, Idl, Program, Provider, web3 } from "@project-serum/anchor"
 import * as marinadeIdl from "./marinade-idl.json"
 import { MarinadeState } from './marinade-state/marinade-state'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
-import { getOrCreateAssociatedTokenAccount, SYSTEM_PROGRAM_ID } from './util/anchor'
+import { getAssociatedTokenAccountAddress, getOrCreateAssociatedTokenAccount, SYSTEM_PROGRAM_ID } from './util/anchor'
 import { MarinadeResult } from './marinade.types'
 
 export class Marinade {
@@ -29,7 +29,7 @@ export class Marinade {
     const transaction = new web3.Transaction()
 
     const {
-      associatedTokenAccountAddress,
+      associatedTokenAccountAddress: associatedLPTokenAccountAddress,
       createAccociateTokenInstruction,
     } = await getOrCreateAssociatedTokenAccount(this.anchorProvider, marinadeState.lpMintAddress, ownerAddress)
 
@@ -43,13 +43,11 @@ export class Marinade {
         accounts: {
           state: this.config.marinadeStateAddress,
           lpMint: marinadeState.lpMintAddress,
-          lpMintAuthority: marinadeState.lpMintAuthority,
-
+          lpMintAuthority: await marinadeState.lpMintAuthority(),
           liqPoolMsolLeg: marinadeState.mSolLeg,
           liqPoolSolLegPda: await marinadeState.solLeg(),
-
           transferFrom: ownerAddress,
-          mintTo: associatedTokenAccountAddress,
+          mintTo: associatedLPTokenAccountAddress,
           systemProgram: SYSTEM_PROGRAM_ID,
           tokenProgram: TOKEN_PROGRAM_ID,
         },
@@ -60,7 +58,51 @@ export class Marinade {
     const transactionSignature = await this.anchorProvider.send(transaction)
 
     return {
-      associatedTokenAccountAddress,
+      associatedLPTokenAccountAddress,
+      transactionSignature,
+    }
+  }
+
+  async removeLiquidity (amountLamports: BN | number): Promise<MarinadeResult.RemoveLiquidity> {
+    const ownerAddress = this.config.wallet.publicKey
+    const marinadeState = await this.getMarinadeState()
+    const transaction = new web3.Transaction()
+
+    const associatedLPTokenAccountAddress = await getAssociatedTokenAccountAddress(marinadeState.lpMintAddress, ownerAddress)
+
+    const {
+      associatedTokenAccountAddress: associatedMSolTokenAccountAddress,
+      createAccociateTokenInstruction,
+    } = await getOrCreateAssociatedTokenAccount(this.anchorProvider, marinadeState.mSolMintAddress, ownerAddress)
+
+    if (createAccociateTokenInstruction) {
+      transaction.add(createAccociateTokenInstruction)
+    }
+    const removeLiquidityInstruction = await this.marinadeProgram.instruction.removeLiquidity(
+      new BN(amountLamports),
+      {
+        accounts: {
+          state: this.config.marinadeStateAddress,
+          lpMint: marinadeState.lpMintAddress,
+          burnFrom: associatedLPTokenAccountAddress,
+          burnFromAuthority: this.config.wallet.publicKey,
+          liqPoolSolLegPda: await marinadeState.solLeg(),
+          transferSolTo: ownerAddress,
+          transferMsolTo: associatedMSolTokenAccountAddress,
+          liqPoolMsolLeg: marinadeState.mSolLeg,
+          liqPoolMsolLegAuthority: await marinadeState.mSolLegAuthority(),
+          systemProgram: SYSTEM_PROGRAM_ID,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        },
+      }
+    )
+
+    transaction.add(removeLiquidityInstruction)
+    const transactionSignature = await this.anchorProvider.send(transaction)
+
+    return {
+      associatedLPTokenAccountAddress,
+      associatedMSolTokenAccountAddress,
       transactionSignature,
     }
   }

--- a/src/marinade.ts
+++ b/src/marinade.ts
@@ -1,34 +1,22 @@
-#!/bin/node
-import { program } from "commander";
-import { show } from "./commands/show.js";
+import { Config } from "./modules/config"
+import { Idl, Program, Provider, web3 } from "@project-serum/anchor"
+import * as marinadeIdl from "./marinade-idl.json"
+import { MarinadeState } from './marinade-state/marinade-state'
 
-async function main(argv: string[], _env: Record<string, unknown>) {
+export class Marinade {
+  constructor (public readonly config: Config = new Config()) {}
 
-  program
-    .version("0.0.1")
-    .allowExcessArguments(false);
+  readonly anchorProvider = Provider.local(this.config.anchorProviderUrl)
 
-  program
-    .command("show")
-    .description("show marinade state")
-    .action(show);
+  get marinadeProgram (): Program {
+    return new Program(
+      marinadeIdl as Idl,
+      this.config.marinadeProgramId,
+      this.anchorProvider,
+    )
+  }
 
-  // program
-  //   .command("stake <amount>")
-  //   .description("stake SOL get mSOL")
-  //   .action(stake);
-
-  // program
-  //   .command("unstake <amount>")
-  //   .option("-f, --max-fee","max fee accepted")
-  //   .option("-m, --min-sol","min SOL accepted")
-  //   .option("--sol","amount measured in sol")
-  //   .description("unstake mSOL, get SOL")
-  //   .action(unstakeNow);
-
-  program.parse(argv);
-
+  async getMarinadeState (): Promise<MarinadeState> {
+    return MarinadeState.fetch(this)
+  }
 }
-
-main(process.argv, process.env);
-

--- a/src/marinade.ts
+++ b/src/marinade.ts
@@ -1,10 +1,13 @@
-import { Config } from "./modules/config"
-import { Idl, Program, Provider, web3 } from "@project-serum/anchor"
+import { MarinadeConfig } from "./modules/marinade-config"
+import { BN, Idl, Program, Provider, web3 } from "@project-serum/anchor"
 import * as marinadeIdl from "./marinade-idl.json"
 import { MarinadeState } from './marinade-state/marinade-state'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { getOrCreateAssociatedTokenAccount, SYSTEM_PROGRAM_ID } from './util/anchor'
+import { MarinadeResult } from './marinade.types'
 
 export class Marinade {
-  constructor (public readonly config: Config = new Config()) {}
+  constructor (public readonly config: MarinadeConfig = new MarinadeConfig()) {}
 
   readonly anchorProvider = Provider.local(this.config.anchorProviderUrl)
 
@@ -18,5 +21,47 @@ export class Marinade {
 
   async getMarinadeState (): Promise<MarinadeState> {
     return MarinadeState.fetch(this)
+  }
+
+  async addLiquidity (amountLamports: BN | number): Promise<MarinadeResult.AddLiquidity> {
+    const ownerAddress = this.config.wallet.publicKey
+    const marinadeState = await this.getMarinadeState()
+    const transaction = new web3.Transaction()
+
+    const {
+      associatedTokenAccountAddress,
+      createAccociateTokenInstruction,
+    } = await getOrCreateAssociatedTokenAccount(this.anchorProvider, marinadeState.lpMintAddress, ownerAddress)
+
+    if (createAccociateTokenInstruction) {
+      transaction.add(createAccociateTokenInstruction)
+    }
+
+    const addLiquidityInstruction = await this.marinadeProgram.instruction.addLiquidity(
+      new BN(amountLamports),
+      {
+        accounts: {
+          state: this.config.marinadeStateAddress,
+          lpMint: marinadeState.lpMintAddress,
+          lpMintAuthority: marinadeState.lpMintAuthority,
+
+          liqPoolMsolLeg: marinadeState.mSolLeg,
+          liqPoolSolLegPda: await marinadeState.solLeg(),
+
+          transferFrom: ownerAddress,
+          mintTo: associatedTokenAccountAddress,
+          systemProgram: SYSTEM_PROGRAM_ID,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        },
+      }
+    )
+
+    transaction.add(addLiquidityInstruction)
+    const transactionSignature = await this.anchorProvider.send(transaction)
+
+    return {
+      associatedTokenAccountAddress,
+      transactionSignature,
+    }
   }
 }

--- a/src/marinade.types.ts
+++ b/src/marinade.types.ts
@@ -1,0 +1,8 @@
+import { web3 } from '@project-serum/anchor'
+
+export namespace MarinadeResult {
+  export interface AddLiquidity {
+    associatedTokenAccountAddress: web3.PublicKey
+    transactionSignature: any
+  }
+}

--- a/src/marinade.types.ts
+++ b/src/marinade.types.ts
@@ -2,7 +2,13 @@ import { web3 } from '@project-serum/anchor'
 
 export namespace MarinadeResult {
   export interface AddLiquidity {
-    associatedTokenAccountAddress: web3.PublicKey
+    associatedLPTokenAccountAddress: web3.PublicKey
+    transactionSignature: any
+  }
+
+  export interface RemoveLiquidity {
+    associatedLPTokenAccountAddress: web3.PublicKey
+    associatedMSolTokenAccountAddress: web3.PublicKey
     transactionSignature: any
   }
 }

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -1,0 +1,13 @@
+import { web3 } from "@project-serum/anchor"
+
+const loadEnvVariable = (envVariableKey: string, defValue: string): string => process.env[envVariableKey] ?? defValue
+
+export class Config {
+  marinadeProgramId = new web3.PublicKey("MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD")
+  marinadeStateAddress = new web3.PublicKey("8szGkuLTAux9XMgZ2vtY39jVSowEcpBfFfD8hXSEqdGC")
+  anchorProviderUrl = loadEnvVariable("ANCHOR_PROVIDER_URL", "http://api.mainnet-beta.solana.com")
+
+  constructor (configOverrides: Partial<Config> = {}) {
+    Object.assign(this, configOverrides)
+  }
+}

--- a/src/modules/marinade-config.ts
+++ b/src/modules/marinade-config.ts
@@ -2,12 +2,14 @@ import { web3 } from "@project-serum/anchor"
 
 const loadEnvVariable = (envVariableKey: string, defValue: string): string => process.env[envVariableKey] ?? defValue
 
-export class Config {
+export class MarinadeConfig {
   marinadeProgramId = new web3.PublicKey("MarBmsSgKXdrN1egZf5sqe1TMai9K1rChYNDJgjq7aD")
   marinadeStateAddress = new web3.PublicKey("8szGkuLTAux9XMgZ2vtY39jVSowEcpBfFfD8hXSEqdGC")
-  anchorProviderUrl = loadEnvVariable("ANCHOR_PROVIDER_URL", "http://api.mainnet-beta.solana.com")
+  // anchorProviderUrl = loadEnvVariable("ANCHOR_PROVIDER_URL", "https://api.mainnet-beta.solana.com")
+  anchorProviderUrl = loadEnvVariable("ANCHOR_PROVIDER_URL", "https://api.devnet.solana.com")
+  wallet = web3.Keypair.generate()
 
-  constructor (configOverrides: Partial<Config> = {}) {
+  constructor (configOverrides: Partial<MarinadeConfig> = {}) {
     Object.assign(this, configOverrides)
   }
 }

--- a/src/util/anchor.ts
+++ b/src/util/anchor.ts
@@ -4,20 +4,22 @@ import { AccountInfo, ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } fro
 
 export const SYSTEM_PROGRAM_ID = new web3.PublicKey('11111111111111111111111111111111')
 
-export const getMintClient = (anchorProvider: Provider, mintAddress: web3.PublicKey): Token =>
-  new Token(anchorProvider.connection, mintAddress, TOKEN_PROGRAM_ID, web3.Keypair.generate())
+export function getMintClient (anchorProvider: Provider, mintAddress: web3.PublicKey): Token {
+  return new Token(anchorProvider.connection, mintAddress, TOKEN_PROGRAM_ID, web3.Keypair.generate())
+}
 
-export const getAssociatedTokenAccountAddress = (mint: web3.PublicKey, owner: web3.PublicKey): Promise<web3.PublicKey> =>
-  anchor.utils.token.associatedAddress({ mint, owner })
+export async function getAssociatedTokenAccountAddress (mint: web3.PublicKey, owner: web3.PublicKey): Promise<web3.PublicKey> {
+  return anchor.utils.token.associatedAddress({ mint, owner })
+}
 
+export async function getTokenAccountInfo (mintClient: Token, publicKey: web3.PublicKey): Promise<AccountInfo> {
+  return mintClient.getAccountInfo(publicKey)
+}
 
-export const getTokenAccountInfo = async (mintClient: Token, publicKey: web3.PublicKey): Promise<AccountInfo> =>
-  mintClient.getAccountInfo(publicKey)
-
-export const getOrCreateAssociatedTokenAccount = async (anchorProvider: anchor.Provider, mintAddress: web3.PublicKey, ownerAddress: web3.PublicKey): Promise<{
+export async function getOrCreateAssociatedTokenAccount (anchorProvider: anchor.Provider, mintAddress: web3.PublicKey, ownerAddress: web3.PublicKey): Promise<{
   associatedTokenAccountAddress: web3.PublicKey
   createAccociateTokenInstruction: web3.TransactionInstruction | null
-}> => {
+}> {
   const associatedTokenAccountAddress = await getAssociatedTokenAccountAddress(mintAddress, ownerAddress)
   let createAccociateTokenInstruction: web3.TransactionInstruction | null = null
 

--- a/src/util/anchor.ts
+++ b/src/util/anchor.ts
@@ -1,7 +1,47 @@
 import { Provider, web3 } from '@project-serum/anchor'
-import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import * as anchor from '@project-serum/anchor'
+import { AccountInfo, ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } from '@solana/spl-token'
 
-// @todo add payer argument
-export const mintClient = (anchorProvider: Provider, mintAddress: web3.PublicKey): Token => {
-  return new Token(anchorProvider.connection, mintAddress, TOKEN_PROGRAM_ID, web3.Keypair.generate())
+export const SYSTEM_PROGRAM_ID = new web3.PublicKey('11111111111111111111111111111111')
+
+export const getMintClient = (anchorProvider: Provider, mintAddress: web3.PublicKey): Token =>
+  new Token(anchorProvider.connection, mintAddress, TOKEN_PROGRAM_ID, web3.Keypair.generate())
+
+export const getAssociatedTokenAccountAddress = (mint: web3.PublicKey, owner: web3.PublicKey): Promise<web3.PublicKey> =>
+  anchor.utils.token.associatedAddress({ mint, owner })
+
+
+export const getTokenAccountInfo = async (mintClient: Token, publicKey: web3.PublicKey): Promise<AccountInfo> =>
+  mintClient.getAccountInfo(publicKey)
+
+export const getOrCreateAssociatedTokenAccount = async (anchorProvider: anchor.Provider, mintAddress: web3.PublicKey, ownerAddress: web3.PublicKey): Promise<{
+  associatedTokenAccountAddress: web3.PublicKey
+  createAccociateTokenInstruction: web3.TransactionInstruction | null
+}> => {
+  const associatedTokenAccountAddress = await getAssociatedTokenAccountAddress(mintAddress, ownerAddress)
+  let createAccociateTokenInstruction: web3.TransactionInstruction | null = null
+
+  const mintClient = getMintClient(anchorProvider, mintAddress)
+
+  try {
+    await getTokenAccountInfo(mintClient, associatedTokenAccountAddress)
+  } catch (err) {
+    if (!(err instanceof Error) || err.message !== 'Failed to find account') {
+      throw err
+    }
+
+    createAccociateTokenInstruction = Token.createAssociatedTokenAccountInstruction(
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+      TOKEN_PROGRAM_ID,
+      mintAddress,
+      associatedTokenAccountAddress,
+      ownerAddress,
+      anchorProvider.wallet.publicKey
+    )
+  }
+
+  return {
+    associatedTokenAccountAddress,
+    createAccociateTokenInstruction,
+  }
 }

--- a/src/util/anchor.ts
+++ b/src/util/anchor.ts
@@ -1,0 +1,7 @@
+import { Provider, web3 } from '@project-serum/anchor'
+import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token'
+
+// @todo add payer argument
+export const mintClient = (anchorProvider: Provider, mintAddress: web3.PublicKey): Token => {
+  return new Token(anchorProvider.connection, mintAddress, TOKEN_PROGRAM_ID, web3.Keypair.generate())
+}

--- a/src/util/conversion.ts
+++ b/src/util/conversion.ts
@@ -1,19 +1,21 @@
 import { BN } from "@project-serum/anchor";
 
 const SOL_DECIMALS = 9
-const LAMPORTS_PER_SOL = 10 ** SOL_DECIMALS
 
-export const withDecimalPoint = (bn: BN, decimals: number): string => {
+export function withDecimalPoint (bn: BN, decimals: number): string {
   const s = bn.toString().padStart(decimals + 1, '0')
   const l = s.length
   return s.slice(0, l - decimals) + "." + s.slice(-decimals)
 }
 
-export const tokenBalanceToNumber = (bn: BN, decimals: number): number =>
-  Number(withDecimalPoint(bn, decimals))
+export function tokenBalanceToNumber (bn: BN, decimals: number): number {
+  return Number(withDecimalPoint(bn, decimals))
+}
 
-export const lamportsToSolNumber = (bn: BN): number =>
-  tokenBalanceToNumber(bn, SOL_DECIMALS)
+export function lamportsToSolNumber (bn: BN): number {
+  return tokenBalanceToNumber(bn, SOL_DECIMALS)
+}
 
-export const solToLamportsBN = (amountSol: number): BN =>
-  new BN(LAMPORTS_PER_SOL).muln(amountSol)
+export function solToLamportsBN (amountSol: number): BN {
+  return new BN(amountSol.toFixed(SOL_DECIMALS).replace('.', ''))
+}

--- a/src/util/conversion.ts
+++ b/src/util/conversion.ts
@@ -1,6 +1,7 @@
 import { BN } from "@project-serum/anchor";
 
-const LAMPORTS_PER_SOL = 1e9
+const SOL_DECIMALS = 9
+const LAMPORTS_PER_SOL = 10 ** SOL_DECIMALS
 
 export function withDecimalPoint(bn: BN, decimals: number): string {
   const s = bn.toString().padStart(decimals + 1, '0')
@@ -12,8 +13,8 @@ export function tokenBalanceToNumber(bn: BN, decimals: number): number {
   return Number(withDecimalPoint(bn, decimals))
 }
 
-export function lamportsToSolBN(bn: BN): number {
-  return tokenBalanceToNumber(bn, 9)
+export function lamportsToSolNumber(bn: BN): number {
+  return tokenBalanceToNumber(bn, SOL_DECIMALS)
 }
 
 

--- a/src/util/conversion.ts
+++ b/src/util/conversion.ts
@@ -3,18 +3,17 @@ import { BN } from "@project-serum/anchor";
 const SOL_DECIMALS = 9
 const LAMPORTS_PER_SOL = 10 ** SOL_DECIMALS
 
-export function withDecimalPoint(bn: BN, decimals: number): string {
+export const withDecimalPoint = (bn: BN, decimals: number): string => {
   const s = bn.toString().padStart(decimals + 1, '0')
   const l = s.length
   return s.slice(0, l - decimals) + "." + s.slice(-decimals)
 }
 
-export function tokenBalanceToNumber(bn: BN, decimals: number): number {
-  return Number(withDecimalPoint(bn, decimals))
-}
+export const tokenBalanceToNumber = (bn: BN, decimals: number): number =>
+  Number(withDecimalPoint(bn, decimals))
 
-export function lamportsToSolNumber(bn: BN): number {
-  return tokenBalanceToNumber(bn, SOL_DECIMALS)
-}
+export const lamportsToSolNumber = (bn: BN): number =>
+  tokenBalanceToNumber(bn, SOL_DECIMALS)
 
-
+export const solToLamportsBN = (amountSol: number): BN =>
+  new BN(LAMPORTS_PER_SOL).muln(amountSol)


### PR DESCRIPTION
Kicking off the transformation of this repo to a TS client.
1) Allowing usage in other TS/nodeJS projects (`new Marinade(...)`)
2) Allowing previously intended behaviour of using as an executable script (e.g. `node dist/marinade-cli show`)

Testing of the changes:
The output of the current `show` command remains the same:
```
{ ...omitted state }

Stake Account Count 15
Min Stake Amounts 1

mSol Price 1

--- mSOL-SOL swap pool
LP Mint LPmSozJJ8Jh69ut2WP3XmVohTjL4ipR18yiCzxrUmVj
  LP supply:  263.455146327
  SOL leg UefNb6z6yvArqe4cJHTXCqStRsKmWhGxnZzuHbikP5Q
  SOL leg Balance 301.264085328
  mSOL leg 7GgPYjS5Dza89wV6FpZ23kUJRG5vbQ1GM25ezspYFSoE
  mSOL leg Balance 3.869171828
  Total Liq pool value (SOL)  305.133257156
  mSOL-SOL-LP price (SOL) 1.158198127
  Liquidity Target:  10000
  Current-fee: 3%
  Min-Max-Fee: 0.3% to 3%
  fee to unstake-now! 250000 SOL: 3%

--- TVL
  Total Staked Value (SOL)  983
  Total Liquidity-Pool (SOL)  305
  TVL (SOL)  1,288
```