### PR TITLE
Fix web3js upgrade changes

### DIFF
--- a/packages/lib/anchor-common/package.json
+++ b/packages/lib/anchor-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/anchor-common",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Solana Anchor JS utilities",
   "repository": {
     "type": "git",
@@ -29,15 +29,15 @@
     "@solana/web3.js": "^1.98.0",
     "bn.js": "^5.2.1",
     "@coral-xyz/anchor": "^0.29.0",
-    "@marinade.finance/ts-common": "2.4.10",
-    "@marinade.finance/web3js-common": "2.4.10"
+    "@marinade.finance/ts-common": "2.4.11",
+    "@marinade.finance/web3js-common": "2.4.11"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.98.0",
     "bn.js": "^5.2.1",
     "@coral-xyz/anchor": "^0.29.0",
-    "@marinade.finance/ts-common": "2.4.10",
-    "@marinade.finance/web3js-common": "2.4.10",
+    "@marinade.finance/ts-common": "2.4.11",
+    "@marinade.finance/web3js-common": "2.4.11",
     "@anza-xyz/solana-rpc-get-stake-activation": "1.0.1"
   },
   "engines": {

--- a/packages/lib/bankrun-utils/package.json
+++ b/packages/lib/bankrun-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/bankrun-utils",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Bankrun library utilities",
   "repository": {
     "type": "git",
@@ -26,14 +26,14 @@
   ],
   "devDependencies": {
     "@solana/web3.js": "^1.98.0",
-    "@marinade.finance/web3js-common": "2.4.10",
+    "@marinade.finance/web3js-common": "2.4.11",
     "solana-bankrun": "^0.2.0",
     "anchor-bankrun": "^0.2.0",
     "class-transformer": "^0.5.1"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.98.0",
-    "@marinade.finance/web3js-common": "2.4.10",
+    "@marinade.finance/web3js-common": "2.4.11",
     "solana-bankrun": "^0.2.0",
     "anchor-bankrun": "^0.2.0",
     "class-transformer": "^0.5.1"

--- a/packages/lib/cli-common/package.json
+++ b/packages/lib/cli-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/cli-common",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "CLI tooling",
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   ],
   "devDependencies": {
     "@solana/web3.js": "^1.98.0",
-    "@marinade.finance/web3js-common": "2.4.10",
-    "@marinade.finance/ts-common": "2.4.10",
+    "@marinade.finance/web3js-common": "2.4.11",
+    "@marinade.finance/ts-common": "2.4.11",
     "@marinade.finance/ledger-utils": "^3.0.1",
     "bn.js": "^5.2.1",
     "borsh": "^0.7.0",
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.98.0",
-    "@marinade.finance/web3js-common": "2.4.10",
-    "@marinade.finance/ts-common": "2.4.10",
+    "@marinade.finance/web3js-common": "2.4.11",
+    "@marinade.finance/ts-common": "2.4.11",
     "@marinade.finance/ledger-utils": "^3.0.1",
     "bn.js": "^5.2.1",
     "borsh": "^0.7.0",

--- a/packages/lib/cli-common/src/error.ts
+++ b/packages/lib/cli-common/src/error.ts
@@ -37,7 +37,8 @@ export class CliCommandError extends ExecutionError {
     } else {
       errorMessage = format('%s: %s', commandName, msg)
     }
-    super({ msg: errorMessage, cause, logs, transaction })
+    const config = { msg: errorMessage, cause, logs, transaction }
+    super(config)
   }
 
   static fromMsg(msg: string): CliCommandError {

--- a/packages/lib/jest-utils/package.json
+++ b/packages/lib/jest-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@marinade.finance/jest-utils",
-    "version": "2.4.10",
+    "version": "2.4.11",
     "description": "Utility functions for setting up Jest",
     "repository": {
       "type": "git",

--- a/packages/lib/spl-gov-utils/package.json
+++ b/packages/lib/spl-gov-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@marinade.finance/spl-gov-utils",
-    "version": "2.4.10",
+    "version": "2.4.11",
     "description": "SPL Governance Marinade constants",
     "repository": {
       "type": "git",

--- a/packages/lib/ts-common/package.json
+++ b/packages/lib/ts-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@marinade.finance/ts-common",
-    "version": "2.4.10",
+    "version": "2.4.11",
     "description": "TS common utilities",
     "repository": {
       "type": "git",

--- a/packages/lib/umi-utils/package.json
+++ b/packages/lib/umi-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/umi-utils",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Umi library utilities",
   "repository": {
     "type": "git",
@@ -28,13 +28,13 @@
     "@solana/web3.js": "^1.98.0",
     "@metaplex-foundation/umi-bundle-defaults": "1.0.0",
     "@metaplex-foundation/umi": "1.0.0",
-    "@marinade.finance/web3js-common": "2.4.10"
+    "@marinade.finance/web3js-common": "2.4.11"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.98.0",
     "@metaplex-foundation/umi-bundle-defaults": "1.0.0",
     "@metaplex-foundation/umi": "1.0.0",
-    "@marinade.finance/web3js-common": "2.4.10"
+    "@marinade.finance/web3js-common": "2.4.11"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/packages/lib/web3js-common/package.json
+++ b/packages/lib/web3js-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/web3js-common",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Web3 JS reusable utilities",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "src"
   ],
   "devDependencies": {
-    "@marinade.finance/ts-common": "2.4.10",
+    "@marinade.finance/ts-common": "2.4.11",
     "@solana/web3.js": "^1.98.0",
     "@solana/buffer-layout": "^4.0.1",
     "bn.js": "^5.2.1",
@@ -32,7 +32,7 @@
     "bs58": "^6.0.0"
   },
   "peerDependencies": {
-    "@marinade.finance/ts-common": "2.4.10",
+    "@marinade.finance/ts-common": "2.4.11",
     "@solana/web3.js": "^1.98.0",
     "@solana/buffer-layout": "^4.0.1",
     "bn.js": "^5.2.1",

--- a/packages/lib/web3js-common/src/tx.ts
+++ b/packages/lib/web3js-common/src/tx.ts
@@ -593,20 +593,22 @@ export type TransactionData<T extends Transaction | VersionedTransaction> = {
  */
 export class TransactionInstructionSplitMarkerStart extends TransactionInstruction {
   constructor() {
-    super({
+    const config = {
       keys: [],
       programId: PublicKey.default,
       data: Buffer.alloc(0),
-    })
+    }
+    super(config)
   }
 }
 export class TransactionInstructionSplitMarkerEnd extends TransactionInstruction {
   constructor() {
-    super({
+    const config = {
       keys: [],
       programId: PublicKey.default,
       data: Buffer.alloc(0),
-    })
+    }
+    super(config)
   }
 }
 export const SPLIT_MARKER_START_INSTANCE =

--- a/packages/marinade-ts-cli/package.json
+++ b/packages/marinade-ts-cli/package.json
@@ -41,13 +41,13 @@
         "pino": "^9.6.0",
         "pino-pretty": "^11.2.1",
         "@marinade.finance/ledger-utils": "^3.0.1",
-        "@marinade.finance/cli-common": "2.4.10",
-        "@marinade.finance/web3js-common": "2.4.10",
+        "@marinade.finance/cli-common": "2.4.11",
+        "@marinade.finance/web3js-common": "2.4.11",
         "@marinade.finance/marinade-ts-sdk": "5.0.7",
         "@anza-xyz/solana-rpc-get-stake-activation": "1.0.1"
     },
     "devDependencies": {
-        "@marinade.finance/jest-utils": "2.4.10",
+        "@marinade.finance/jest-utils": "2.4.11",
         "@types/bn.js": "^5.1.5",
         "@solana/spl-token-3.x": "npm:@solana/spl-token@^0.3.11"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,11 +62,11 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@marinade.finance/ts-common':
-        specifier: 2.4.10
-        version: 2.4.10
+        specifier: 2.4.11
+        version: 2.4.11
       '@marinade.finance/web3js-common':
-        specifier: 2.4.10
-        version: 2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+        specifier: 2.4.11
+        version: 2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -77,8 +77,8 @@ importers:
   packages/lib/bankrun-utils:
     devDependencies:
       '@marinade.finance/web3js-common':
-        specifier: 2.4.10
-        version: 2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+        specifier: 2.4.11
+        version: 2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -96,13 +96,13 @@ importers:
     devDependencies:
       '@marinade.finance/ledger-utils':
         specifier: ^3.0.1
-        version: 3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        version: 3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.11)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@marinade.finance/ts-common':
-        specifier: 2.4.10
-        version: 2.4.10
+        specifier: 2.4.11
+        version: 2.4.11
       '@marinade.finance/web3js-common':
-        specifier: 2.4.10
-        version: 2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+        specifier: 2.4.11
+        version: 2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -148,8 +148,8 @@ importers:
   packages/lib/umi-utils:
     devDependencies:
       '@marinade.finance/web3js-common':
-        specifier: 2.4.10
-        version: 2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+        specifier: 2.4.11
+        version: 2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
       '@metaplex-foundation/umi':
         specifier: 1.0.0
         version: 1.0.0
@@ -163,8 +163,8 @@ importers:
   packages/lib/web3js-common:
     devDependencies:
       '@marinade.finance/ts-common':
-        specifier: 2.4.10
-        version: 2.4.10
+        specifier: 2.4.11
+        version: 2.4.11
       '@solana/buffer-layout':
         specifier: ^4.0.1
         version: 4.0.1
@@ -190,17 +190,17 @@ importers:
         specifier: '0.28'
         version: 0.28.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@marinade.finance/cli-common':
-        specifier: 2.4.10
-        version: 2.4.10(@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@marinade.finance/ts-common@2.4.10)(@marinade.finance/web3js-common@2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(pino@9.6.0)(yaml@2.4.5)
+        specifier: 2.4.11
+        version: 2.4.11(@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.11)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@marinade.finance/ts-common@2.4.11)(@marinade.finance/web3js-common@2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(pino@9.6.0)(yaml@2.4.5)
       '@marinade.finance/ledger-utils':
         specifier: ^3.0.1
-        version: 3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        version: 3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.11)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@marinade.finance/marinade-ts-sdk':
         specifier: 5.0.7
         version: 5.0.7(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10)
       '@marinade.finance/web3js-common':
-        specifier: 2.4.10
-        version: 2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+        specifier: 2.4.11
+        version: 2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
       '@solana/spl-governance':
         specifier: ^0.3.28
         version: 0.3.28(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -230,8 +230,8 @@ importers:
         version: 11.2.1
     devDependencies:
       '@marinade.finance/jest-utils':
-        specifier: 2.4.10
-        version: 2.4.10(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))
+        specifier: 2.4.11
+        version: 2.4.11(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))
       '@solana/spl-token-3.x':
         specifier: npm:@solana/spl-token@^0.3.11
         version: '@solana/spl-token@0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)'
@@ -735,13 +735,13 @@ packages:
   '@ledgerhq/logs@6.12.0':
     resolution: {integrity: sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==}
 
-  '@marinade.finance/cli-common@2.4.10':
-    resolution: {integrity: sha512-RkOBmc40FtVyWzwGm8eRk8evW1OHuqpeZVlEPtPw+QQQyJn5X+nQQ6+UH3Uxe1p5o6qly7W6jcka6Sx8kDwlUQ==}
+  '@marinade.finance/cli-common@2.4.11':
+    resolution: {integrity: sha512-aft+5hy5CH+rrhY6/hYy54oPgKjQUapSer3pLV4yWSHVC9+2YCNdJGXQHBBBnFl7f47vLO70O1IlqW0zsoSKkg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@marinade.finance/ledger-utils': ^3.0.1
-      '@marinade.finance/ts-common': 2.4.10
-      '@marinade.finance/web3js-common': 2.4.10
+      '@marinade.finance/ts-common': 2.4.11
+      '@marinade.finance/web3js-common': 2.4.11
       '@solana/web3.js': ^1.98.0
       bn.js: ^5.2.1
       borsh: ^0.7.0
@@ -757,8 +757,8 @@ packages:
       bn.js: ^5.2.1
       jsbi: ^4.3.0
 
-  '@marinade.finance/jest-utils@2.4.10':
-    resolution: {integrity: sha512-NaiHFM1VyaNRclBTnHOLGLyk/Q9uAIyYHD8Qr7EKTB4wiRH6BiPkXEiefVLGslK+sRfOahcNaE3+Hjw3UWAqsA==}
+  '@marinade.finance/jest-utils@2.4.11':
+    resolution: {integrity: sha512-hH1ytMUocu/VYgc201/J+FaoVISRxnWYy82DamXATEDClu4hiUiPLsOwByZN/+oG2OJbE1D+VHLg6+9Zxz9VLw==}
     peerDependencies:
       '@jest/globals': ^29.7.0
       '@solana/web3.js': ^1.98.0
@@ -781,14 +781,14 @@ packages:
   '@marinade.finance/native-staking-sdk@1.1.0':
     resolution: {integrity: sha512-+iuJLEBIcBgYETkshEGIhwQqUvbjCJ0rHV6BHNOiJur2ppMbswaaCsj3DPu0yJiB2PWvzItZGZMo+BSWUxvJvg==}
 
-  '@marinade.finance/ts-common@2.4.10':
-    resolution: {integrity: sha512-Ku4l54Jh7qSQT2ptoVmLyceFmHQsQtn17e8ybuUTnAMHqqBVAXBw7VGnZtILv9Zexk+TaZiJgfWEgi77My8J5w==}
+  '@marinade.finance/ts-common@2.4.11':
+    resolution: {integrity: sha512-zQRhG6X2lSkiBGoikfoi2uTSoQutCPnPt0ZkpiDbkuVqykUiY3eLJBCt3OyMLzQkMvlhuBnSCyaOcGKWmrnDpg==}
 
-  '@marinade.finance/web3js-common@2.4.10':
-    resolution: {integrity: sha512-L7MljE9UUQRmqopESl329TKq+f6MMKJ63VFrtQR5PMCYCwPslSYq7Z2csfNq1Now+9OLUmnyWe3YeFDuajpfVQ==}
+  '@marinade.finance/web3js-common@2.4.11':
+    resolution: {integrity: sha512-YEW2AaC75JX7Ad1jSnp4WDwjklggCJLz6C5KaK3jJ345b0lOh5MBg3Owc9jVZpKwUgkbmurv5jkll0qMgGGOzw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@marinade.finance/ts-common': 2.4.10
+      '@marinade.finance/ts-common': 2.4.11
       '@solana/buffer-layout': ^4.0.1
       '@solana/web3.js': ^1.98.0
       bn.js: ^5.2.1
@@ -4058,11 +4058,11 @@ snapshots:
 
   '@ledgerhq/logs@6.12.0': {}
 
-  '@marinade.finance/cli-common@2.4.10(@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@marinade.finance/ts-common@2.4.10)(@marinade.finance/web3js-common@2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(pino@9.6.0)(yaml@2.4.5)':
+  '@marinade.finance/cli-common@2.4.11(@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.11)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(@marinade.finance/ts-common@2.4.11)(@marinade.finance/web3js-common@2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0))(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)(pino@9.6.0)(yaml@2.4.5)':
     dependencies:
-      '@marinade.finance/ledger-utils': 3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@marinade.finance/ts-common': 2.4.10
-      '@marinade.finance/web3js-common': 2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
+      '@marinade.finance/ledger-utils': 3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.11)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@marinade.finance/ts-common': 2.4.11
+      '@marinade.finance/web3js-common': 2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
       borsh: 0.7.0
@@ -4082,19 +4082,19 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@marinade.finance/jest-utils@2.4.10(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))':
+  '@marinade.finance/jest-utils@2.4.11(@jest/globals@29.7.0)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(jest-shell-matchers@1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5))))':
     dependencies:
       '@jest/globals': 29.7.0
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
       jest-shell-matchers: 1.0.2(jest@29.7.0(@types/node@22.10.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.4.5)))
 
-  '@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.10)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@marinade.finance/ledger-utils@3.0.1(@ledgerhq/errors@6.16.1)(@ledgerhq/hw-app-solana@7.1.2)(@ledgerhq/hw-transport-node-hid-noevents@6.29.2)(@marinade.finance/ts-common@2.4.11)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@ledgerhq/errors': 6.16.1
       '@ledgerhq/hw-app-solana': 7.1.2
       '@ledgerhq/hw-transport-node-hid-noevents': 6.29.2
-      '@marinade.finance/ts-common': 2.4.10
+      '@marinade.finance/ts-common': 2.4.11
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
   '@marinade.finance/marinade-ts-sdk@5.0.7(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(jsbi@4.3.0)(utf-8-validate@5.0.10)':
@@ -4125,11 +4125,11 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@marinade.finance/ts-common@2.4.10': {}
+  '@marinade.finance/ts-common@2.4.11': {}
 
-  '@marinade.finance/web3js-common@2.4.10(@marinade.finance/ts-common@2.4.10)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)':
+  '@marinade.finance/web3js-common@2.4.11(@marinade.finance/ts-common@2.4.11)(@solana/buffer-layout@4.0.1)(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bn.js@5.2.1)(borsh@0.7.0)(bs58@6.0.0)':
     dependencies:
-      '@marinade.finance/ts-common': 2.4.10
+      '@marinade.finance/ts-common': 2.4.11
       '@solana/buffer-layout': 4.0.1
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1


### PR DESCRIPTION
I'm sorry one more update on this. An update to web3.js 1.98.0 caused an issue in extending a transaction instruction class. It was not clear in any way there is some incompatibility and it was hit only on the dependent project.